### PR TITLE
ci: fix windows build by copying lx to msys2 and refactor workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,16 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate tag format
-        if: github.event_name == 'push'
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid tag format: $TAG. Expected semver format (e.g., v1.0.0 or v1.0.0-rc.1)"
-            exit 1
-          fi
-          echo "✓ Tag format valid: $TAG"
-
       - name: Install Lux
         uses: lumen-oss/gh-actions-lux@v1
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,7 @@ jobs:
           install: >-
             git
             make
+            unzip
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-lua
@@ -77,23 +78,22 @@ jobs:
         with:
           version: 0.28.0
 
-      - name: Install just
+      - name: Copy Lux to MSYS2 (Windows)
+        if: matrix.target == 'windows'
+        run: cp "/c/Program Files/lux/lx.exe" /usr/bin/lx.exe
+
+      - name: Install just (Unix)
+        if: matrix.target != 'windows'
+        uses: extractions/setup-just@v2
+
+      - name: Install just (Windows)
+        if: matrix.target == 'windows'
         run: |
-          if [ "${{ matrix.target }}" = "linux" ]; then
-            mkdir -p /tmp/just
-            curl -L https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-unknown-linux-musl.tar.gz -o /tmp/just/just.tar.gz
-            tar -xzf /tmp/just/just.tar.gz -C /tmp/just
-            sudo mv /tmp/just/just /usr/local/bin/
-            rm -rf /tmp/just
-          elif [ "${{ matrix.target }}" = "macos" ]; then
-            brew install just
-          else
-            mkdir -p /tmp/just
-            curl -L https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-pc-windows-msvc.zip -o /tmp/just/just.zip
-            unzip /tmp/just/just.zip -d /tmp/just
-            mv /tmp/just/just.exe /usr/bin/
-            rm -rf /tmp/just
-          fi
+          mkdir -p /tmp/just
+          curl -L https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-pc-windows-msvc.zip -o /tmp/just/just.zip
+          unzip /tmp/just/just.zip -d /tmp/just
+          mv /tmp/just/just.exe /usr/bin/
+          rm -rf /tmp/just
 
       - name: Build Executable
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,13 +24,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y lua5.4 liblua5.4-dev cmake
 
-      - name: Install just
-        run: |
-          mkdir -p /tmp/just
-          curl -L https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-unknown-linux-musl.tar.gz -o /tmp/just/just.tar.gz
-          tar -xzf /tmp/just/just.tar.gz -C /tmp/just
-          sudo mv /tmp/just/just /usr/local/bin/
-          rm -rf /tmp/just
+      - uses: extractions/setup-just@v2
 
       - name: Run tests
         run: just test-ci
@@ -47,13 +41,7 @@ jobs:
         with:
           version: 0.28.0
 
-      - name: Install just
-        run: |
-          mkdir -p /tmp/just
-          curl -L https://github.com/casey/just/releases/download/1.48.1/just-1.48.1-x86_64-unknown-linux-musl.tar.gz -o /tmp/just/just.tar.gz
-          tar -xzf /tmp/just/just.tar.gz -C /tmp/just
-          sudo mv /tmp/just/just /usr/local/bin/
-          rm -rf /tmp/just
+      - uses: extractions/setup-just@v2
 
       - name: Install GitHub CLI (if missing)
         run: |


### PR DESCRIPTION
## Summary
- Explicitly copy lx.exe into MSYS2 environment for windows build
- Simplify just installation using setup-just action
- Add unzip to MSYS2 dependencies explicitly
- Remove redundant tag validation from publish workflow