### PR TITLE
fix(ci): fix Windows build and upgrade Lux + action dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ jobs:
     environment: luarocks-publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Lux
-        uses: lumen-oss/gh-actions-lux@60bee431bba7e65b608b8aa309be0eb0252f5e79 # v1.0.0
+        uses: lumen-oss/gh-actions-lux@bd58f7b97fe2147910580a33b677efadf746e179 # v1.0.1
         with:
-          version: 0.28.0
+          version: 0.28.2
 
       - name: Install LuaRocks (for validation)
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ jobs:
           - os: macos-latest
             name: macos-x86_64
             target: macos
-          - os: windows-latest
+          - os: windows-2022
             name: windows-x86_64
             target: windows
     runs-on: ${{ matrix.os }}
@@ -65,11 +65,11 @@ jobs:
         shell: ${{ matrix.target == 'windows' && 'msys2 {0}' || 'bash' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup MSYS2 (Windows)
         if: matrix.target == 'windows'
-        uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2.24.1
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
         with:
           msystem: UCRT64
           update: true
@@ -99,9 +99,9 @@ jobs:
           brew install cmake luarocks lua@5.4
 
       - name: Install Lux
-        uses: lumen-oss/gh-actions-lux@60bee431bba7e65b608b8aa309be0eb0252f5e79 # v1.0.0
+        uses: lumen-oss/gh-actions-lux@bd58f7b97fe2147910580a33b677efadf746e179 # v1.0.1
         with:
-          version: 0.28.0
+          version: 0.28.2
 
       - name: Copy Lux to MSYS2 (Windows)
         if: matrix.target == 'windows'
@@ -119,6 +119,10 @@ jobs:
           unzip /tmp/just/just.zip -d /tmp/just
           mv /tmp/just/just.exe /usr/bin/
           rm -rf /tmp/just
+
+      - name: Add Lux build dependencies bin to PATH (Windows)
+        if: matrix.target == 'windows'
+        run: echo "${{ github.workspace }}/.lux/5.4/build_dependencies/5.4/bin" >> "$GITHUB_PATH"
 
       - name: Build Executable
         env:
@@ -153,6 +157,7 @@ jobs:
             export MACOSX_DEPLOYMENT_TARGET="11.0"
             just build
           else
+            export CC="gcc"
             export LUA_PREFIX="/ucrt64"
             export LUA_LIB="/ucrt64/lib/liblua.a"
             export LUA_INCLUDE="/ucrt64/include"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Lux
-        uses: lumen-oss/gh-actions-lux@60bee431bba7e65b608b8aa309be0eb0252f5e79 # v1.0.0
+        uses: lumen-oss/gh-actions-lux@bd58f7b97fe2147910580a33b677efadf746e179 # v1.0.1
         with:
-          version: 0.28.0
+          version: 0.28.2
 
       - name: Install system dependencies
         run: |
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Lux
-        uses: lumen-oss/gh-actions-lux@60bee431bba7e65b608b8aa309be0eb0252f5e79 # v1.0.0
+        uses: lumen-oss/gh-actions-lux@bd58f7b97fe2147910580a33b677efadf746e179 # v1.0.1
         with:
-          version: 0.28.0
+          version: 0.28.2
 
       - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 

--- a/justfile
+++ b/justfile
@@ -164,7 +164,11 @@ build-luv: prep
 build-system: prep
     @echo "Building static luasystem..."
     {{ if path_exists(build_dir / "luasystem") == "true" { "" } else { "git clone https://github.com/o-lim/luasystem.git " + (build_dir / "luasystem") } }}
-    cd {{ build_dir / 'luasystem' }} && {{ cc }} -Wno-error=incompatible-pointer-types -c src/core.c src/compat.c src/time.c -I{{ lua_include }}
+    cd {{ build_dir / 'luasystem' }} && {{ cc }} \
+      -Wno-error=incompatible-pointer-types \
+      {{ if os() == "windows" { "-D_WIN32_WINNT=0x0601" } else { "" } }} \
+      -c src/core.c src/compat.c src/time.c \
+      -I{{ lua_include }}
     cd {{ build_dir / 'luasystem' }} && ar rcs libsystem.a core.o compat.o time.o
     cp {{ build_dir / 'luasystem' / 'libsystem.a' }} {{ build_dir }}/
 
@@ -174,13 +178,14 @@ build-system: prep
 compile:
     @echo {{ assert(path_exists("bin/spin.lua") == "true", "bin/spin.lua not found - CLI entry point missing") }}
     @echo "Compiling standalone binary..."
-    cd lua && lx --lua-version {{ lua_version }} exec -- luastatic ../bin/spin.lua \
+    cd lua && PATH="/ucrt64/bin:$PATH" lx --lua-version {{ lua_version }} exec -- luastatic ../bin/spin.lua \
       roda/init.lua roda/spinners.lua roda/ansi.lua roda/symbols.lua roda/util.lua roda/argp.lua \
       {{ build_dir / 'libluv.a' }} {{ build_dir / 'libuv.a' }} {{ build_dir / 'libsystem.a' }} {{ lua_lib }} \
+      {{ if os() == "windows" { "-lwinmm -lws2_32" } else { "" } }} \
       -I{{ lua_include }} && \
     mv spin.luastatic.c {{ build_dir }}/ && \
     cd .. && \
-    mv lua/spin roda
+    mv lua/{{ if os() == "windows" { "spin.exe" } else { "spin" } }} {{ if os() == "windows" { "roda.exe" } else { "roda" } }}
 
 [doc("Test the standalone executable")]
 [group('test')]


### PR DESCRIPTION
## Summary

Fixes the failing Windows release artifact build (`Build Release Artifacts (windows-latest, windows-x86_64, windows)`) and upgrades all pinned action dependencies to Node.js 24-compatible versions.

## Root Causes Fixed

The Windows build had three compounding failures:

1. **`luastatic` not on PATH** — `lx exec` spawns a subprocess that doesn't inherit the MSYS2 PATH, so `gcc` (called by `luastatic` via `os.execute()`) was not found. Fixed by prepending `/ucrt64/bin` to PATH inside the `compile` recipe and adding an explicit `GITHUB_PATH` step in the workflow.

2. **`spin.exe` not renamed to `roda.exe`** — `luastatic` produces `spin.exe` on Windows, but the recipe unconditionally ran `mv lua/spin roda`. Fixed with a `just` `os()` conditional.

3. **Missing Win32 compile flags** — `luasystem`'s `src/core.c` requires `-D_WIN32_WINNT=0x0601` for proper Win32 API header resolution under MinGW-w64 UCRT64, and the final link step needs `-lwinmm -lws2_32`. Both added.

## Changes

### `justfile`
- `build-system`: Add `-D_WIN32_WINNT=0x0601` compile flag on Windows
- `compile`: Prepend `/ucrt64/bin` to PATH for `lx exec` subprocess; add `-lwinmm -lws2_32` linker flags on Windows; rename `spin.exe` → `roda.exe` on Windows via `os()` conditional

### `.github/workflows/release-please.yml`
- Pin Windows runner to `windows-2022` (non-rolling)
- Add `GITHUB_PATH` step for Lux build-deps bin dir (Windows only)
- Set `CC=gcc` explicitly in Windows build branch
- Upgrade `actions/checkout` v4.2.2 → v6.0.2 (SHA pinned)
- Upgrade `msys2/setup-msys2` v2.24.1 → v2.31.1 (SHA pinned)
- Upgrade `gh-actions-lux` v1.0.0 → v1.0.1 (SHA pinned)
- Upgrade Lux CLI `0.28.0` → `0.28.2` (includes Windows lib prefix fix)

### `.github/workflows/tests.yml` + `publish.yml`
- Upgrade `actions/checkout` v4.2.2 → v6.0.2 (SHA pinned, 3 occurrences)
- Upgrade `gh-actions-lux` v1.0.0 → v1.0.1 (SHA pinned)
- Upgrade Lux CLI `0.28.0` → `0.28.2`

## Dependency Upgrade Rationale

| Dependency | Old | New | Reason |
|---|---|---|---|
| Lux CLI | 0.28.0 | 0.28.2 | Windows lib prefix fix (`lux-lib`: drop lib prefix on Windows) |
| `actions/checkout` | v4.2.2 | v6.0.2 | Node.js 20 deprecated; forced to Node.js 24 on 2026-06-02 |
| `gh-actions-lux` | v1.0.0 | v1.0.1 | Initial Marketplace release |
| `msys2/setup-msys2` | v2.24.1 | v2.31.1 | Node.js 20 deprecated; forced to Node.js 24 on 2026-06-02 |

## Testing

The Windows build job should now complete successfully. The Linux and macOS jobs are unaffected — the `os()` conditionals in the `justfile` evaluate to the `else` branch on those platforms, and the workflow PATH step is gated on `matrix.target == 'windows'`.